### PR TITLE
warning on quadratic_bezier_interpolate becoming private in the future

### DIFF
--- a/addons/2d_regular_polygons/regular_polygon_2d/RegularPolygon2D.cs
+++ b/addons/2d_regular_polygons/regular_polygon_2d/RegularPolygon2D.cs
@@ -190,8 +190,7 @@ public class RegularPolygon2D
        float drawnArc = Mathf.Tau, bool addCentralPoint = true)
     => _shared.Value.Call(MethodName.GetShapeVertices, verticesCount, size, offsetRotation, offsetPosition, drawnArc, addCentralPoint).AsVector2Array();
     /// <summary>
-    /// Returns the point at the given <paramref name="t"/> on the Bézier curve with the given 
-    /// <paramref name="start"/>, <paramref name="end"/>, and single <paramref name="control"/> points.
+    /// WARNING: This method is not meant to be used outside the class, and will be removed in the future
     /// </summary>
     public static Vector2 QuadraticBezierInterpolate(Vector2 start, Vector2 control, Vector2 end, float t)
     => _shared.Value.Call(MethodName.QuadraticBezierInterpolate, start, control, end, t).AsVector2();

--- a/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
@@ -389,7 +389,7 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 		current_point = next_point
 
 # Returns the point at the given [param t] on the Bézier curve with the given [param start], [param end], and single [param control] point.
-## [b]Warning[/b]: This method is not meant to be used outside the class, and will be changed/made private in the future.
+## [b][color=red]Warning[/color][/b]: This method is not meant to be used outside the class, and will be changed/made private in the future.
 static func quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
 

--- a/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
@@ -388,7 +388,8 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 		last_point = current_point
 		current_point = next_point
 
-## Returns the point at the given [param t] on the Bézier curve with the given [param start], [param end], and single [param control] point.
+# Returns the point at the given [param t] on the Bézier curve with the given [param start], [param end], and single [param control] point.
+## [b]Warning[/b]: This method is not meant to be used outside the class, and will be changed/made private in the future.
 static func quadratic_bezier_interpolate(start : Vector2, control : Vector2, end : Vector2, t : float) -> Vector2:
 	return control + (t - 1) ** 2 * (start - control) + t ** 2 * (end - control)
 


### PR DESCRIPTION
the method "quadratic_bezier_interpolate" in [RegularPolygon2D](addons/2d_regular_polygons/regular_polygon_2d.gd) shouldn't be publicly available, as it is only used within the class. Godot already provides the more commonly used version. 

The documentation on the method (in both gd and c# versions) has been changed to alert users that it shouldn't be used and will be made private in the future. 