### PR TITLE
Added `_get_configuration_warnings` for most nodes

### DIFF
--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -75,6 +75,7 @@ var drawn_arc : float = TAU:
 	set(value):
 		drawn_arc = value
 		queue_regenerate()
+		update_configuration_warnings()
 
 ## The distance from each vertex along the edge to the point where the rounded corner starts.
 ## If this value is over half of the edge length, the mid-point of the edge is used instead.
@@ -292,6 +293,11 @@ func _init(vertices_count := 1, size := 10.0, offset_rotation := 0.0, width := 0
 		self.corner_size = corner_size
 	if corner_smoothness != 0:
 		self.corner_smoothness = corner_smoothness
+
+func _get_configuration_warnings() -> PackedStringArray:
+	if drawn_arc == 0:
+		return ["Collision shapes will not be regenerated when 'drawn_arc' is 0."]
+	return []
 
 ## Modifies [param segments] to form an outline of the interconnected segments with the given [param width].
 ## [param join_perimeter] controls whether the function should extend (or shorten) line segments to form a propery closed shape.

--- a/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
@@ -94,6 +94,7 @@ var drawn_arc : float = TAU:
 	set(value):
 		drawn_arc = value
 		_pre_redraw()
+		update_configuration_warnings()
 
 ## The distance from each vertex along the edge to the point where the rounded corner starts.
 ## If this value is over half of the edge length, the mid-point of the edge is used instead.
@@ -272,6 +273,11 @@ func _init(vertices_count : int = 1, size := 10.0, offset_rotation := 0.0, color
 	if corner_smoothness != 0:
 		self.corner_smoothness = corner_smoothness
 	
+func _get_configuration_warnings() -> PackedStringArray:
+	if drawn_arc == 0:
+		return ["nothing will be drawn when 'drawn_arc' is 0."]
+	return []
+
 ## Checks whether the current properties of this node will have it use [member Polygon2d.polygon].
 func uses_polygon_member() -> bool:
 	return (

--- a/addons/2d_regular_polygons/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/2d_regular_polygons/star_polygon_2d/star_polygon_2d.gd
@@ -99,6 +99,7 @@ var drawn_arc : float = TAU:
 	set(value):
 		drawn_arc = value
 		_pre_redraw()
+		update_configuration_warnings()
 
 ## The distance from each vertex along the edge to the point where the rounded corner starts.
 ## If this value is over half of the edge length, the mid-point of the edge is used instead.
@@ -260,6 +261,11 @@ func _init(vertices_count : int = 1, size := 10.0, inner_size := 5.0, offset_rot
 		self.corner_size = corner_size
 	if corner_smoothness != 0:
 		self.corner_smoothness = corner_smoothness
+
+func _get_configuration_warnings() -> PackedStringArray:
+	if drawn_arc == 0:
+		return ["Nothing will be drawn when 'drawn_arc' is 0."]
+	return []
 
 ## Checks whether the current properties of this node will have it use [member Polygon2d.polygon].
 func uses_polygon_member() -> bool:


### PR DESCRIPTION
Adds `_get_configuration_warnings` for most nodes (not `SimplePolygon2D`). They all warn when the `drawn_arc` property is set to 0, which prevents them from working properly.