### PR TITLE
Fixes `ConvexPolygonShape2D` being used for a convex shape.

### DIFF
--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -299,6 +299,19 @@ func _get_configuration_warnings() -> PackedStringArray:
 		return ["Collision shapes will not be regenerated when 'drawn_arc' is 0."]
 	return []
 
+static func convert_to_line_segments(points : PackedVector2Array) -> PackedVector2Array:
+	var original_size := points.size()
+	points.resize(original_size * 2)
+	
+	for i in original_size:
+		var index := original_size - i - 1
+		var point := points[index]
+
+		points[index * 2] = point
+		points[index * 2 - 1] = point
+
+	return points
+
 ## Modifies [param segments] to form an outline of the interconnected segments with the given [param width].
 ## [param join_perimeter] controls whether the function should extend (or shorten) line segments to form a propery closed shape.
 ## For disconnected segments, use [method widen_polyline].

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -267,11 +267,11 @@ func regenerate() -> void:
 		shape = square
 		return
 	
-	var polygon := ConvexPolygonShape2D.new()
 	var points := RegularPolygon2D.get_shape_vertices(vertices_count, size, offset_rotation, Vector2.ZERO, drawn_arc)
 	if uses_rounded_corners:
 		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count)
 	
+	var polygon := ConvexPolygonShape2D.new()
 	polygon.points = points 
 	shape = polygon
 

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -305,7 +305,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 		return ["Collision shapes will not be regenerated when 'drawn_arc' is 0."]
 	return []
 
-## Modifies and returns [param points] with the identical shape represented by line segments.
+## Modifies and returns [param points] with the identical shape represented with line segments.
 static func convert_to_line_segments(points : PackedVector2Array) -> PackedVector2Array:
 	var original_size := points.size()
 	points.resize(original_size * 2)

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -271,6 +271,12 @@ func regenerate() -> void:
 	if uses_rounded_corners:
 		RegularPolygon2D.add_rounded_corners(points, corner_size, corner_smoothness if corner_smoothness != 0 else 32 / vertices_count)
 	
+	if uses_drawn_arc and (drawn_arc > PI or drawn_arc < -PI):
+		var lines := ConcavePolygonShape2D.new()
+		lines.segments = convert_to_line_segments(points)
+		shape = lines
+		return
+
 	var polygon := ConvexPolygonShape2D.new()
 	polygon.points = points 
 	shape = polygon

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -305,6 +305,7 @@ func _get_configuration_warnings() -> PackedStringArray:
 		return ["Collision shapes will not be regenerated when 'drawn_arc' is 0."]
 	return []
 
+## Modifies and returns [param points] with the identical shape represented by line segments.
 static func convert_to_line_segments(points : PackedVector2Array) -> PackedVector2Array:
 	var original_size := points.size()
 	points.resize(original_size * 2)


### PR DESCRIPTION
see #13

When a concave shape is detected, `ConcavePolygonShape2D` is used instead. 

The static method `RegularCollisionPolygon2D.convert_to_line_segments` was also added to convert points into line segments.