### PR TITLE
Maintain `custom_solver_bias` through regeneration

### DIFF
--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -307,8 +307,9 @@ func regenerate() -> void:
 	polygon.points = points
 	_set_shape(polygon)
 
-func _set_shape(new_shape : Shape2D):
-	new_shape.custom_solver_bias = shape.custom_solver_bias
+func _set_shape(new_shape : Shape2D) -> void:
+	if shape != null:
+		new_shape.custom_solver_bias = shape.custom_solver_bias
 	shape = new_shape
 
 func _uses_drawn_arc() -> bool:

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -308,6 +308,10 @@ func regenerate() -> void:
 	polygon.points = points 
 	shape = polygon
 
+func _set_shape(new_shape : Shape2D):
+	new_shape.custom_solver_bias = shape.custom_solver_bias
+	shape = new_shape
+
 func _uses_drawn_arc() -> bool:
 	return -TAU < drawn_arc and drawn_arc < TAU
 

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -150,7 +150,7 @@ func regenerate() -> void:
 				var line := SegmentShape2D.new()
 				line.a = point1
 				line.b = point2
-				shape = line
+				_set_shape(line)
 				return
 			
 			if not uses_inner_size:
@@ -158,14 +158,14 @@ func regenerate() -> void:
 					var rect_line := RectangleShape2D.new()
 					rect_line.size.y = size * 2
 					rect_line.size.x = width
-					shape = rect_line
+					_set_shape(rect_line)
 					return
 
 				if is_zero_approx(point1.y):
 					var rect_line := RectangleShape2D.new()
 					rect_line.size.y = width
 					rect_line.size.x = size * 2
-					shape = rect_line
+					_set_shape(rect_line)
 					return
 			
 			var line := ConvexPolygonShape2D.new()
@@ -177,7 +177,7 @@ func regenerate() -> void:
 			array[2] = point2 + tangent
 			array[3] = point2 - tangent
 			line.points = array
-			shape = line
+			_set_shape(line)
 			return
 		
 		point2 = SimplePolygon2D._get_vertices(offset_rotation + drawn_arc + PI) * size
@@ -192,7 +192,7 @@ func regenerate() -> void:
 			if width > 0:
 				widen_multiline(array, width)
 			lines.segments = array
-			shape = lines
+			_set_shape(lines)
 			return
 		
 		if is_equal_approx(PI, abs(drawn_arc)):
@@ -203,7 +203,7 @@ func regenerate() -> void:
 			if width > 0:
 				widen_polyline(array, width, false)
 			lines.segments = array
-			shape = lines
+			_set_shape(lines)
 			return
 		
 		var smoothness := corner_smoothness if corner_smoothness != 0 else 16
@@ -226,7 +226,7 @@ func regenerate() -> void:
 		if width > 0:
 			widen_polyline(array, width, true)
 		lines.segments = array
-		shape = lines
+		_set_shape(lines)
 		return
 	
 	var uses_rounded_corners := not is_zero_approx(corner_size)
@@ -269,8 +269,7 @@ func regenerate() -> void:
 			segments[(modified_size - i) * 2 - 2] = points[original_size - i - 2 - offset]
 		
 		polygon.segments = segments 
-		
-		shape = polygon
+		_set_shape(polygon)
 		return
 	
 	var vertices := vertices_count
@@ -278,7 +277,7 @@ func regenerate() -> void:
 		if drawn_arc >= TAU or drawn_arc <= -TAU:
 			var circle := CircleShape2D.new()
 			circle.radius = size
-			shape = circle
+			_set_shape(circle)
 			return
 		vertices = 32
 	
@@ -286,7 +285,7 @@ func regenerate() -> void:
 		const sqrt_two_over_two := 0.707106781
 		var square := RectangleShape2D.new()
 		square.size = size / sqrt_two_over_two * Vector2.ONE
-		shape = square
+		_set_shape(square)
 		return
 	
 	var points : PackedVector2Array
@@ -301,12 +300,12 @@ func regenerate() -> void:
 	if uses_drawn_arc and (drawn_arc > PI or drawn_arc < -PI) or uses_inner_size and vertices_count > 2:
 		var lines := ConcavePolygonShape2D.new()
 		lines.segments = convert_to_line_segments(points)
-		shape = lines
+		_set_shape(lines)
 		return
 
 	var polygon := ConvexPolygonShape2D.new()
-	polygon.points = points 
-	shape = polygon
+	polygon.points = points
+	_set_shape(polygon)
 
 func _set_shape(new_shape : Shape2D):
 	new_shape.custom_solver_bias = shape.custom_solver_bias

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -111,7 +111,9 @@ var _is_queued := true
 
 ## Queues [method regenerate] for the next process frame. If this method is called multiple times, the shape is only regenerated once.
 ## [br][br]If this method is called when the node is outside the [SceneTree], [member Shape2D.shape] will be set to [code]null[/code]
-## and initialization will be delayed to when the node enters the tree. Call [method regenerate] directly to force initialization.
+## and initialization will be delayed to when the node enters the tree.
+## This also means that [member Shape2D.custom_solver_bias] won't be maintained and will be reset to [code]0[/code].
+## Call [method regenerate] directly to force initialization.
 func queue_regenerate() -> void:
 	if _is_queued:
 		return
@@ -131,6 +133,7 @@ func _enter_tree() -> void:
 	_is_queued = false
 
 ## Regenerates the [member CollisionShape2D.shape] using the properties of this node.
+## [br][br]The value of [member Shape2D.custom_solver_bias] of the new [Shape2D] will be the same a the previous, if [member shape] isn't [value]null[/value].
 func regenerate() -> void:
 	_is_queued = false
 	


### PR DESCRIPTION
`RegularCollisionPolygon2D` sets the `custom_solver_bias` property of a newly created `Shape2D` with the value on the previous shape, if it exists.

This is accomplished using the method `_set_shape()`, which should now be used instead of directly setting `shape` (except to null, then don't use the method).


Due to internal structuring, this does not work when calling `queue_regenerate()` when the node is outside the scene tree as it sets the property to null before regenerating, so `custom_solver_bias` can't be found.

I don't intend on fixing this currently as it's a niece scenario that can be easily worked around by using `regenerate()` instead.