### PR TITLE
Fix invalid generation of certain configurations on `RegularPolygon2D` and `RegularCollisionPolygon2D`

### DIFF
--- a/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
@@ -444,6 +444,11 @@ static func add_hole_to_points(points : PackedVector2Array, hole_scaler : float,
 
 	for i in original_size:
 		points[-i - 1] = points[i] * hole_scaler
+	
+	if close_shape:
+		var slope := (points[original_size - 2] - points[original_size - 1]).normalized() * 0.0005
+		points[original_size - 1] += slope
+		points[original_size] += slope
 
 # these functions are for c# interop, as changes to an argument are not transferred.
 static func _add_rounded_corners_result(points : PackedVector2Array, corner_size : float, corner_smoothness : int) -> PackedVector2Array:

--- a/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
@@ -403,12 +403,12 @@ static func add_rounded_corners(points : PackedVector2Array, corner_size : float
 		var starting_point : Vector2
 		var ending_point : Vector2
 		if starting_slope.length_squared() / 4 < corner_size_squared:
-			starting_point = current_point - starting_slope / 2
+			starting_point = current_point - starting_slope / 2.001
 		else:
 			starting_point = current_point - starting_slope.normalized() * corner_size
 		
 		if ending_slope.length_squared() / 4 < corner_size_squared:
-			ending_point = current_point - ending_slope / 2
+			ending_point = current_point - ending_slope / 2.001
 		else:
 			ending_point = current_point - ending_slope.normalized() * corner_size
 


### PR DESCRIPTION
Specifically, it fixes #14 and #22 by making it so that points are not allowed to overlap. Instead, there is a slight gap between them. 

The distance is absolute for the #14 fix, so the issue may still exist if `size` is large enough such that the small change is ignored as it is out of precision (I think). The workaround of having `drawn_arc` set to a value slightly below `TAU` still works for that.

The distance is relative for the #22 fix, and the change also affects `RegularPolygon2D` and `StarPolygon2D`. At large `size` values, it isn't very noticeable unless `corner_smoothness = 1`, so this side effect is acceptable to me.