### PR TITLE
Improves queueing functionality of shape regeneration.

### DIFF
--- a/.gut_editor_config.json
+++ b/.gut_editor_config.json
@@ -34,7 +34,7 @@
  "post_run_script": "",
  "pre_run_script": "",
  "prefix": "test_",
- "selected": "test_regular_collision_polygon_2d.gd",
+ "selected": null,
  "should_exit": false,
  "should_exit_on_success": false,
  "should_maximize": false,

--- a/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd
@@ -7,8 +7,8 @@ extends CollisionShape2D
 ##
 ## A node with variables for generating 2d regular shapes for collision.
 ## It creates various shape inheriting [Shape2D] based on the values of its variables and sets it to [member CollisionShape2D.shape].
-## [br][br][b]Note[/b]: If properties are set when the node is outside the [SceneTree], the shape isn't generated instantly.
-## See [method queue_regenerate] for its effects.
+## [br][br][b]Note[/b]: If properties are set when the node is outside the [SceneTree],
+## regeneration will be delayed to when it enters one. Use [method regenerate] to force regeneration.
 
 ## The number of vertices in the regular shape. A value of [code]1[/code] creates a circle, and a value of [code]2[/code] creates a line.
 ## [br][br]Certain properties with circles will use a 32-sided polygon instead.
@@ -115,9 +115,7 @@ const _BLOCK_QUEUE = 2
 var _queue_status : int = _NOT_QUEUED 
 
 ## Queues [method regenerate] for the next process frame. If this method is called multiple times, the shape is only regenerated once.
-## [br][br]If this method is called when the node is outside the [SceneTree], [member Shape2D.shape] will be set to [code]null[/code]
-## and initialization will be delayed to when the node enters the tree.
-## This also means that [member Shape2D.custom_solver_bias] won't be maintained and will be reset to [code]0[/code].
+## [br][br]If this method is called when the node is outside the [SceneTree], regeneration will be delayed to when the node enters the tree.
 ## Call [method regenerate] directly to force initialization.
 func queue_regenerate() -> void:
 	if _queue_status != _NOT_QUEUED:

--- a/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
+++ b/addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd
@@ -9,8 +9,7 @@ extends Polygon2D
 ## It uses methods like [method CanvasItem.draw_colored_polygon] or [method CanvasItem.draw_circle], or use [member Polygon2D.polygon].
 ## Certain properties with circles will use a 32-sided polygon instead.
 ## [br][br][b]Note[/b]: If the node is set to use [member Polygon2D.polygon] when it is outside the [SceneTree],
-## [member Polygon2D.polygon] will be cleared and will be set when the node enters the tree.
-## Use [method regenerate_polygon] to force  [member Polygon2D.polygon] to be set outside the [SceneTree].
+## regeneration will be delayed to when it enters it. Use [method regenerate_polygon] to force regeneration.
 ## [br][br][b]Warning[/b]: Specific values which use a value of [member width] between [code]0[/code] and [member size]
 ## (such as a hexagon with [member width] half of [member size]) will cause the node to fail to draw shape.
 ## This can be worked around by slightly altering properties, like subtracting [code]0.01[/code] from [member width] or [member drawn_arc].

--- a/addons/2d_regular_polygons/star_polygon_2d/star_polygon_2d.gd
+++ b/addons/2d_regular_polygons/star_polygon_2d/star_polygon_2d.gd
@@ -8,8 +8,7 @@ class_name StarPolygon2D
 ## A node that draws star, with complex properties.
 ## It uses [method CanvasItem.draw_colored_polygon], [method CanvasItem.draw_polyline], or [member Polygon2D.polygon]
 ## [br][br][b]Note[/b]: If the node is set to use [member Polygon2D.polygon] when it is outside the [SceneTree],
-## [member Polygon2D.polygon] will be cleared and will be set when the node enters the [SceneTree].
-## Use [method regenerate_polygon] to force  [member Polygon2D.polygon] to be set outside the [SceneTree].
+## regeneration will be delayed to when it enters it. Use [method regenerate_polygon] to force regeneration.
 
 ## The number of points the star has.
 ## [br][br]If set to [code]1[/code], a line is drawn.

--- a/tests/unit_tests/test_regular_collision_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_collision_polygon_2d.gd
@@ -23,7 +23,7 @@ func test_init__filled_params__assigned_to_vars():
 	assert_eq(shape.corner_size, 1.0, "Property 'corner_size'.")
 	assert_eq(shape.corner_smoothness, 1, "Property 'corner_smoothness'.")
 
-func test_enter_tree__queue_blocked__regenerate_not_called_not_queued():
+func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	var shape : RegularCollisionPolygon2D = partial_double(class_script).new() 
 	stub(shape, "regenerate").to_do_nothing()
 	shape.shape = RectangleShape2D.new()
@@ -32,6 +32,13 @@ func test_enter_tree__queue_blocked__regenerate_not_called_not_queued():
 	shape._enter_tree()
 
 	assert_not_called(shape, "regenerate")
+
+func test_enter_tree__not_not_queued__now_not_queued(p= use_parameters([RegularCollisionPolygon2D._IS_QUEUED, RegularCollisionPolygon2D._BLOCK_QUEUE])):
+	var shape : RegularCollisionPolygon2D = partial_double(class_script).new()
+	shape._queue_status = p
+
+	shape._enter_tree()
+
 	assert_eq(shape._queue_status, RegularCollisionPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
 func test_queue_regenerate__not_queued__is_queued():

--- a/tests/unit_tests/test_regular_collision_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_collision_polygon_2d.gd
@@ -23,6 +23,24 @@ func test_init__filled_params__assigned_to_vars():
 	assert_eq(shape.corner_size, 1.0, "Property 'corner_size'.")
 	assert_eq(shape.corner_smoothness, 1, "Property 'corner_smoothness'.")
 
+func test_init__shape_not_null__queue_blocked():
+	var shape := CollisionShape2D.new()
+	autoqfree(shape)
+	shape.shape = CircleShape2D.new()
+
+	shape.set_script(class_script)
+
+	assert_eq(shape._queue_status, RegularCollisionPolygon2D._BLOCK_QUEUE, "Property '_queue_status' should be '_BLOCK_QUEUE' (2)")
+
+func test_init__shape_null__queue_not_blocked():
+	var shape := CollisionShape2D.new()
+	autoqfree(shape)
+	shape.shape = null
+
+	shape.set_script(class_script)
+
+	assert_ne(shape._queue_status, RegularCollisionPolygon2D._BLOCK_QUEUE, "Property '_queue_status' should not be '_BLOCK_QUEUE' (2)")
+
 func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	var shape : RegularCollisionPolygon2D = partial_double(class_script).new() 
 	stub(shape, "regenerate").to_do_nothing()

--- a/tests/unit_tests/test_regular_collision_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_collision_polygon_2d.gd
@@ -7,7 +7,8 @@ func before_each():
 	ignore_method_when_doubling(class_script, "widen_polyline")
 	ignore_method_when_doubling(class_script, "widen_multiline")
 	ignore_method_when_doubling(class_script, "_widen_polyline_result")
-	ignore_method_when_doubling(class_script, "_widen_multiline_result");
+	ignore_method_when_doubling(class_script, "_widen_multiline_result")
+	ignore_method_when_doubling(class_script, "convert_to_line_segments")
 
 func test_init__filled_params__assigned_to_vars():
 	var shape : RegularCollisionPolygon2D
@@ -22,30 +23,29 @@ func test_init__filled_params__assigned_to_vars():
 	assert_eq(shape.corner_size, 1.0, "Property 'corner_size'.")
 	assert_eq(shape.corner_smoothness, 1, "Property 'corner_smoothness'.")
 
-func test_enter_tree__shape_filled__regenerate_not_called():
+func test_enter_tree__queue_blocked__regenerate_not_called_not_queued():
 	var shape : RegularCollisionPolygon2D = partial_double(class_script).new() 
 	stub(shape, "regenerate").to_do_nothing()
 	shape.shape = RectangleShape2D.new()
-	shape._is_queued = true
+	shape._queue_status = RegularCollisionPolygon2D._BLOCK_QUEUE
 
 	shape._enter_tree()
 
 	assert_not_called(shape, "regenerate")
-	assert_false(shape._is_queued, "Variable '_is_queued' should be false (was %s)." % shape._is_queued)
+	assert_eq(shape._queue_status, RegularCollisionPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
-func test_queue_regenerate__shape_filled_outside_tree__shape_null():
+func test_queue_regenerate__not_queued__is_queued():
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())
 	shape.shape = RectangleShape2D.new()
-	shape._is_queued = false
 
 	shape.queue_regenerate()
 
-	assert_null(shape.shape, "Property 'shape'.")
+	assert_eq(shape._queue_status, RegularCollisionPolygon2D._IS_QUEUED, "Property '_queue_status' should be '_IS_QUEUED' (1).")
 
 func test_queue_regenerate__in_tree__delayed_shape_filled():
 	var shape : RegularCollisionPolygon2D = partial_double(class_script).new()
-	shape._is_queued = false
 	stub(shape, "_enter_tree").to_do_nothing()
+	shape._queue_status = RegularCollisionPolygon2D._NOT_QUEUED
 	add_child(shape)
 
 	shape.queue_regenerate()
@@ -54,6 +54,7 @@ func test_queue_regenerate__in_tree__delayed_shape_filled():
 	await wait_for_signal(get_tree().process_frame, 10)
 	await wait_frames(2)
 	assert_not_null(shape.shape, "Property 'shape'.")
+	assert_eq(shape._queue_status, RegularCollisionPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
 func test_regenerate__vertices_count_2__shape_segment_shape():
 	var shape : RegularCollisionPolygon2D = autoqfree(RegularCollisionPolygon2D.new())

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -30,6 +30,24 @@ func test_init__filled__variables_assigned():
 	assert_eq(shape.corner_size, 1.0, "Property 'corner_size'.")
 	assert_eq(shape.corner_smoothness, 1, "Property 'corner_smoothness'.")
 
+func test_init__polygon_not_empty__queue_blocked():
+	var shape := Polygon2D.new()
+	autoqfree(shape)
+	shape.polygon = sample_polygon
+
+	shape.set_script(class_script)
+
+	assert_eq(shape._queue_status, RegularPolygon2D._BLOCK_QUEUE, "Property '_queue_status' should be '_BLOCK_QUEUE' (2)")
+
+func test_init__polygon_empty__queue_not_blocked():
+	var shape := Polygon2D.new()
+	autoqfree(shape)
+	shape.polygon = PackedVector2Array()
+
+	shape.set_script(class_script)
+
+	assert_ne(shape._queue_status, RegularPolygon2D._BLOCK_QUEUE, "Property '_queue_status' should not be '_BLOCK_QUEUE' (2)")
+
 func test_pre_redraw__in_tree_using_polygon__delayed_polygon_fill():
 	var shape : RegularPolygon2D = partial_double(class_script).new()
 	shape.width = 10

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -55,6 +55,14 @@ func test_enter_tree__blocked_queue__polygon_not_regenerated():
 
 	assert_not_called(shape, "regenerate_polygon")
 
+func test_enter_tree__not_not_queued__now_not_queued(p= use_parameters([RegularPolygon2D._IS_QUEUED, RegularPolygon2D._BLOCK_QUEUE])):
+	var shape : RegularPolygon2D = partial_double(class_script).new()
+	shape._queue_status = p
+
+	shape._enter_tree()
+
+	assert_eq(shape._queue_status, RegularPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
+
 func test_regenerate_polygon__holed_shape_without_drawn_arc__ends_equal():
 	var shape : RegularPolygon2D = autoqfree(RegularPolygon2D.new())
 	shape.vertices_count = 4

--- a/tests/unit_tests/test_regular_polygon_2d.gd
+++ b/tests/unit_tests/test_regular_polygon_2d.gd
@@ -33,7 +33,7 @@ func test_init__filled__variables_assigned():
 func test_pre_redraw__in_tree_using_polygon__delayed_polygon_fill():
 	var shape : RegularPolygon2D = partial_double(class_script).new()
 	shape.width = 10
-	shape._is_queued = false
+	shape._queue_status = RegularPolygon2D._NOT_QUEUED
 	stub(shape, "_enter_tree").to_do_nothing()
 	add_child(shape)
 
@@ -43,13 +43,13 @@ func test_pre_redraw__in_tree_using_polygon__delayed_polygon_fill():
 	await wait_for_signal(get_tree().process_frame, 10)
 	await wait_frames(2)
 	assert_false(shape.polygon.is_empty(), "Variable 'polygon' should be a filled array at this point.")
+	assert_eq(shape._queue_status, RegularPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
-func test_enter_tree__regenerate_requested_with_polygon_not_empty__polygon_not_regenerated():
+func test_enter_tree__blocked_queue__polygon_not_regenerated():
 	var shape : RegularPolygon2D = partial_double(class_script).new()
 	stub(shape, "uses_polygon_member").to_return(true)
 	stub(shape, "regenerate_polygon").to_do_nothing()
-	shape._is_queued = true
-	shape.polygon = sample_polygon
+	shape._queue_status = RegularPolygon2D._BLOCK_QUEUE
 
 	shape._enter_tree()
 

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -24,6 +24,24 @@ func test_init__params_filled__assigned_to_vars():
 	assert_eq(star.corner_size, 1.0, "Property 'corner_size'.")
 	assert_eq(star.corner_smoothness, 1, "Property 'corner_smoothness'.")
 
+func test_init__polygon_not_empty__queue_blocked():
+	var star := Polygon2D.new()
+	autoqfree(star)
+	star.polygon = sample_polygon
+
+	star.set_script(class_script)
+
+	assert_eq(star._queue_status, StarPolygon2D._BLOCK_QUEUE, "Property '_queue_status' should be '_BLOCK_QUEUE' (2)")
+
+func test_init__polygon_empty__queue_not_blocked():
+	var star := Polygon2D.new()
+	autoqfree(star)
+	star.polygon = PackedVector2Array()
+
+	star.set_script(class_script)
+
+	assert_ne(star._queue_status, StarPolygon2D._BLOCK_QUEUE, "Property '_queue_status' should not be '_BLOCK_QUEUE' (2)")
+
 func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	stub(shape, "regenerate_polygon").to_do_nothing()

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -24,31 +24,31 @@ func test_init__params_filled__assigned_to_vars():
 	assert_eq(star.corner_size, 1.0, "Property 'corner_size'.")
 	assert_eq(star.corner_smoothness, 1, "Property 'corner_smoothness'.")
 
-func test_enter_tree__polygon_filled__regenerate_not_called():
+func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	var shape : StarPolygon2D = partial_double(class_script).new()
 	stub(shape, "regenerate_polygon").to_do_nothing()
 	shape.polygon = sample_polygon
-	shape._is_queued = true
+	shape._queue_status = StarPolygon2D._BLOCK_QUEUE
 
 	shape._enter_tree()
 
 	assert_not_called(shape, "regenerate_polygon") # does not accept a custom message.
-	assert_false(shape._is_queued, "Variable '_is_queued' should be false.")
+	assert_eq(shape._queue_status, StarPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
-func test_pre_redraw__polygon_filled_outside_tree__polygon_empty():
+func test_pre_redraw__not_queued__is_queued():
 	var star : StarPolygon2D = partial_double(class_script).new()
 	stub(star, "uses_polygon_member").to_return(true)
 	star.polygon = sample_polygon
-	star._is_queued = false
+	star._queue_status = StarPolygon2D._NOT_QUEUED
 
 	star._pre_redraw()
 
-	assert_true(star.polygon.is_empty(), "Variable 'polygon' should be an empty array.")
+	assert_eq(star._queue_status, StarPolygon2D._IS_QUEUED, "Property '_queue_status' should be '_IS_QUEUED' (1).")
 
 func test_queue_regenerate__in_tree__delayed_shape_filled():
 	var star : StarPolygon2D = partial_double(class_script).new()
 	star.width = 10
-	star._is_queued = false
+	star._queue_status = StarPolygon2D._NOT_QUEUED
 	stub(star, "_enter_tree").to_do_nothing()
 	add_child(star)
 
@@ -57,7 +57,8 @@ func test_queue_regenerate__in_tree__delayed_shape_filled():
 	assert_true(star.polygon.is_empty(), "Variable 'polygon' should still be an empty array.")
 	await wait_for_signal(get_tree().process_frame, 10)
 	await wait_frames(2)
-	assert_false(star.polygon.is_empty(), "Variable 'polygon' should be a filled array at this point.")
+	assert_false(star.polygon.is_empty(), "Property 'polygon' should be a filled array at this point.")
+	assert_eq(star._queue_status, StarPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
 func test_get_star_vertices__drawn_arc_PI__no_central_point(p = use_parameters([[PI], [-PI]])):
 	var star : PackedVector2Array

--- a/tests/unit_tests/test_star_polygon_2d.gd
+++ b/tests/unit_tests/test_star_polygon_2d.gd
@@ -33,6 +33,13 @@ func test_enter_tree__blocked_queue__regenerate_not_called_not_queued():
 	shape._enter_tree()
 
 	assert_not_called(shape, "regenerate_polygon") # does not accept a custom message.
+
+func test_enter_tree__not_not_queued__now_not_queued(p= use_parameters([StarPolygon2D._IS_QUEUED, StarPolygon2D._BLOCK_QUEUE])):
+	var shape : StarPolygon2D = partial_double(class_script).new()
+	shape._queue_status = p
+
+	shape._enter_tree()
+
 	assert_eq(shape._queue_status, StarPolygon2D._NOT_QUEUED, "Property '_queue_status' should be '_NOT_QUEUED' (0).")
 
 func test_pre_redraw__not_queued__is_queued():


### PR DESCRIPTION
Improves the queueing functionality of [RegularCollisionPolygon2D](﻿addons/2d_regular_polygons/regular_collision_polygon_2d/regular_collision_polygon_2d.gd), [RegularPolygon2D](addons/2d_regular_polygons/regular_polygon_2d/regular_polygon_2d.gd), and [StarPolygon2D](addons/2d_regular_polygons/star_polygon_2d/star_polygon_2d.gd) (all applicable nodes) such that `polygon`/`shape` isn't cleared when regeneration is requested outside the `SceneTree`. 

This is done by changing `_is_queued : bool` to `_queue_status : int` and using constants as codes. With more values, the node can separate the request for regeneration and the request to block regeneration, which was previously done by setting a request by regeneration and `_init` having a condition for that to go through, namely `polygon`/`shape` being empty. The change also allows for future potential additions to how the queue is used.

Documentation is altered to reflect the new changes, along with Unit Tests which also have new additions.